### PR TITLE
Add known packages with option for latest dev build

### DIFF
--- a/recipe/package-reference.cake
+++ b/recipe/package-reference.cake
@@ -6,6 +6,25 @@ public class PackageReference
 	public string Id { get; }
 	public string Version { get; }
 
+	// Static members provide reference to known packages
+	public static PackageReference Engine = new PackageReference(
+		"TestCentric.Engine", "2.0.0-beta3");
+	public static PackageReference EngineCore = new PackageReference(
+		"TestCentric.Engine.Core", "2.0.0-beta3");
+	public static PackageReference EngineApi = new PackageReference(
+		"TestCentric.Engine.Api", "2.0.0-beata3");
+	public static PackageReference AgentCore = new PackageReference(
+		"TestCentric.Agent.Core", "2.0.0");
+	public static PackageReference Extensibility = new PackageReference(
+		"TestCentric.Extensibility", "2.0.0");
+	public static PackageReference ExtensibilityApi = new PackageReference(
+		"TestCentric.ExtensibilityApi", "2.0.0");
+	public static PackageReference Metadata = new PackageReference(
+		"TestCentric.Metadata", "2.0.0");
+	public static PackageReference GuiRunner = new PackageReference(
+		"TestCentric.GuiRunner", "2.0.0-beta3-1");
+	public static PackageReference InternalTrace = new PackageReference(
+		"TestCentric.InternalTrace", "1.0.0");
 	public PackageReference(string id, string version)
 	{
 		_context = BuildSettings.Context;
@@ -14,7 +33,24 @@ public class PackageReference
 		Version = version;
 	}
 
-	public bool IsInstalled(string installDirectory)
+	private PackageReference _devBuild;
+    public PackageReference LatestDevBuild => _devBuild ?? GetLatestDevBuild();
+	
+	private PackageReference GetLatestDevBuild()
+	{
+		var packageList = _context.NuGetList(Id, new NuGetListSettings()
+		{
+			Prerelease = true, 
+			Source = new [] { "https://www.myget.org/F/testcentric/api/v3/index.json" } 
+		} );
+
+		foreach (var package in packageList)
+			return _devBuild = new PackageReference(package.Name, package.Version);
+		
+		return this;
+	}
+
+    public bool IsInstalled(string installDirectory)
 	{
 		return _context.GetDirectories($"{installDirectory}{Id}.*").Count > 0;
 	}


### PR DESCRIPTION
For use with TestCentric packages, which should always be updated to use the latest dev build from myget.